### PR TITLE
chore: update whatwg-url dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "whatwg-url": "^8.4.0",
-    "@types/whatwg-url": "^8.0.0"
+    "@types/whatwg-url": "^8.2.1",
+    "whatwg-url": "^9.1.0"
   }
 }


### PR DESCRIPTION
Updating this drops two nested dependendcies lodash and punycode.

https://github.com/jsdom/whatwg-url/releases/tag/v9.0.0

An aside, do we need this dependency? isn't URL and URLSearchParams provided in nodejs' 'url' module?