### PR TITLE
feat: use native whatwg-url implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,9 +54,5 @@
     "nyc": "^15.1.0",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.3"
-  },
-  "dependencies": {
-    "@types/whatwg-url": "^8.2.1",
-    "whatwg-url": "^9.1.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,3 @@
-import { URL, URLSearchParams } from 'whatwg-url';
-
 const DUMMY_HOSTNAME = '__this_is_a_placeholder__';
 
 // Adapted from the Node.js driver code:
@@ -110,7 +108,7 @@ export default class ConnectionString extends URLWithoutHost {
       decodeURIComponent(username ?? '');
       decodeURIComponent(password ?? '');
     } catch (err) {
-      throw new MongoParseError(err.message);
+      throw new MongoParseError((err as Error).message);
     }
 
     // characters not permitted in username nor password Set([':', '/', '?', '#', '[', ']', '@'])

--- a/test/index.ts
+++ b/test/index.ts
@@ -105,7 +105,7 @@ describe('ConnectionString', () => {
           // eslint-disable-next-line no-new
           new ConnectionString(uri);
         } catch (err) {
-          expect(err.name).to.equal('MongoParseError');
+          expect((err as Error).name).to.equal('MongoParseError');
           return;
         }
         expect.fail('missed exception');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "declaration": true,
     "removeComments": true,
     "target": "es2018",
-    "lib": ["es2018"],
+    "lib": ["es2018", "dom"],
     "outDir": "./lib",
     "moduleResolution": "node",
     "module": "commonjs"


### PR DESCRIPTION
Related JIRA ticket with more details: https://jira.mongodb.org/browse/NODE-3581

I've just realised after doing this PR that you decided to use the `whatwg-url` npm package due to some browser issue. Is there any more information about this? Is it because of V8 or some other engine? I'm asking because there has been a few fixes since then.

In any case, browser quirks are usually handled by polyfills but if we really want a shim maybe we can use this instead which is much smaller https://github.com/lukeed/url-shim and I believe meets all requirements.