### PR TITLE
chore: Bump gen-esm-wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-standard": "^4.0.1",
-    "gen-esm-wrapper": "^1.1.0",
+    "gen-esm-wrapper": "^1.1.3",
     "mocha": "^8.1.3",
     "nyc": "^15.1.0",
     "ts-node": "^9.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ export default class ConnectionString extends URLWithoutHost {
       decodeURIComponent(username ?? '');
       decodeURIComponent(password ?? '');
     } catch (err) {
-      throw new MongoParseError(err.message);
+      throw new MongoParseError((err as Error).message);
     }
 
     // characters not permitted in username nor password Set([':', '/', '?', '#', '[', ']', '@'])

--- a/test/index.ts
+++ b/test/index.ts
@@ -105,7 +105,7 @@ describe('ConnectionString', () => {
           // eslint-disable-next-line no-new
           new ConnectionString(uri);
         } catch (err) {
-          expect(err.name).to.equal('MongoParseError');
+          expect((err as Error).name).to.equal('MongoParseError');
           return;
         }
         expect.fail('missed exception');


### PR DESCRIPTION
This new version handles esm interop more gracefully.

Before the update (notice the "double-default" export):

<img width="398" alt="image" src="https://user-images.githubusercontent.com/5036933/134208245-53b959df-3778-4985-84b7-633382f44177.png">

And after:

<img width="398" alt="image" src="https://user-images.githubusercontent.com/5036933/134208193-e793d580-4b0e-4af2-be6a-a1a64f6a86ed.png">
