### PR TITLE
chore: bump whatwg-url to 11.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
   },
   "dependencies": {
     "@types/whatwg-url": "^8.2.1",
-    "whatwg-url": "^9.1.0"
+    "whatwg-url": "^11.0.0"
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/mongodb-js/mongodb-connection-string-url/issues/8