### PR TITLE
chore: Always start matching from the beginning of the string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ const DUMMY_HOSTNAME = '__this_is_a_placeholder__';
 // Adapted from the Node.js driver code:
 // https://github.com/mongodb/node-mongodb-native/blob/350d14fde5b24480403313cfe5044f6e4b25f6c9/src/connection_string.ts#L146-L206
 const HOSTS_REGEX = new RegExp(
-  String.raw`(?<protocol>mongodb(?:\+srv|)):\/\/(?:(?<username>[^:]*)(?::(?<password>[^@]*))?@)?(?<hosts>(?!:)[^\/?@]+)(?<rest>.*)`
+  String.raw`^(?<protocol>mongodb(?:\+srv|)):\/\/(?:(?<username>[^:]*)(?::(?<password>[^@]*))?@)?(?<hosts>(?!:)[^\/?@]+)(?<rest>.*)`
 );
 
 class CaseInsensitiveMap extends Map<string, string> {

--- a/test/index.ts
+++ b/test/index.ts
@@ -98,7 +98,9 @@ describe('ConnectionString', () => {
       'mongodb://a[@localhost/',
       'mongodb://a:[@localhost/',
       'mongodb+srv://a,b,c/',
-      'mongodb+srv://a:12345/'
+      'mongodb+srv://a:12345/',
+      'mongodbabc://localhost',
+      'totallynotamongodb://localhost'
     ]) {
       it(`parsing ${uri} throws an MongoParseError`, () => {
         try {


### PR DESCRIPTION
Curret regex does not allow any protocols that are not matching `mongodb` when the extraneous letters are provided after `mongodb` part, but allows to put anything in the protocol before `monogodb` because the regex doesn't enforce the beginning of the line match. This is technically a breaking change, but we probably can consider this a rare enough case that it shouldn't break anything for anyone even if released as minor or a patch.