### PR TITLE
chore: improve invalid connection string message when scheme/protocol is invalid

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,13 @@ export { redactConnectionString, ConnectionStringRedactionOptions };
 
 const DUMMY_HOSTNAME = '__this_is_a_placeholder__';
 
+function connectionStringHasValidScheme(connectionString: string) {
+  return (
+    connectionString.startsWith('mongodb://') ||
+    connectionString.startsWith('mongodb+srv://')
+  );
+}
+
 // Adapted from the Node.js driver code:
 // https://github.com/mongodb/node-mongodb-native/blob/350d14fde5b24480403313cfe5044f6e4b25f6c9/src/connection_string.ts#L146-L206
 const HOSTS_REGEX = new RegExp(
@@ -118,6 +125,10 @@ export default class ConnectionString extends URLWithoutHost {
 
   // eslint-disable-next-line complexity
   constructor(uri: string) {
+    if (!connectionStringHasValidScheme(uri)) {
+      throw new MongoParseError('Invalid schema, expected connection string to start with `mongodb://` or `mongodb+srv://`');
+    }
+
     const match = uri.match(HOSTS_REGEX);
     if (!match) {
       throw new MongoParseError(`Invalid connection string "${uri}"`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,7 +126,7 @@ export default class ConnectionString extends URLWithoutHost {
   // eslint-disable-next-line complexity
   constructor(uri: string) {
     if (!connectionStringHasValidScheme(uri)) {
-      throw new MongoParseError('Invalid schema, expected connection string to start with `mongodb://` or `mongodb+srv://`');
+      throw new MongoParseError('Invalid scheme, expected connection string to start with "mongodb://" or "mongodb+srv://"');
     }
 
     const match = uri.match(HOSTS_REGEX);

--- a/test/index.ts
+++ b/test/index.ts
@@ -90,7 +90,7 @@ describe('ConnectionString', () => {
         // eslint-disable-next-line no-new
         new ConnectionString('totallynotamongodb://outerspace');
       } catch (err) {
-        expect((err as Error).message).to.equal('Invalid schema, expected connection string to start with `mongodb://` or `mongodb+srv://`');
+        expect((err as Error).message).to.equal('Invalid scheme, expected connection string to start with "mongodb://" or "mongodb+srv://"');
         expect((err as Error).name).to.equal('MongoParseError');
         return;
       }

--- a/test/index.ts
+++ b/test/index.ts
@@ -84,6 +84,20 @@ describe('ConnectionString', () => {
     }
   });
 
+  context('with an invalid schema on URI', () => {
+    it('throws an error mentioning the invalid schema', () => {
+      try {
+        // eslint-disable-next-line no-new
+        new ConnectionString('totallynotamongodb://outerspace');
+      } catch (err) {
+        expect((err as Error).message).to.equal('Invalid schema, expected connection string to start with `mongodb://` or `mongodb+srv://`');
+        expect((err as Error).name).to.equal('MongoParseError');
+        return;
+      }
+      expect.fail('missed exception');
+    });
+  });
+
   context('with invalid URIs', () => {
     for (const uri of [
       '',


### PR DESCRIPTION
I think having the errors here be descriptive will probably help users down the line.  This makes it so we can remove this message in Compass: https://github.com/mongodb-js/compass/pull/2692/files#diff-ba79710b42fded58d9766f054a11ba5a3646e74b580689f2dcf8e18404594e2fL199
And VSCode: https://github.com/mongodb-js/vscode/blob/main/src/connectionController.ts#L250

Should we also mention the connection string being passed as we did previously?
`Invalid schema, expected connection string to start with "mongodb://" or "mongodb+srv://"`
vs
`Invalid connection string "totallynotamongodb://outerspace", expected uri to start with "mongodb://" or "mongodb+srv://"`


Any preference on error message?
`MongoDB connection strings begin with "mongodb://" or "mongodb+srv://"`
vs
`Invalid schema, expected connection string to start with "mongodb://" or "mongodb+srv://"`