### PR TITLE
fix: move "@types/whatwg-url" from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/chai": "^4.2.5",
     "@types/mocha": "^8.0.3",
     "@types/node": "^14.11.1",
+    "@types/whatwg-url": "^8.2.1",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.2.0",
     "chai": "^4.2.0",
@@ -56,7 +57,6 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "@types/whatwg-url": "^8.2.1",
     "whatwg-url": "^11.0.0"
   }
 }


### PR DESCRIPTION
https://github.com/mongodb-js/mongodb-connection-string-url/issues/15