### PR TITLE
fix: check missing host after auth COMPASS-5471

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ function connectionStringHasValidScheme(connectionString: string) {
 // Adapted from the Node.js driver code:
 // https://github.com/mongodb/node-mongodb-native/blob/350d14fde5b24480403313cfe5044f6e4b25f6c9/src/connection_string.ts#L146-L206
 const HOSTS_REGEX = new RegExp(
-  String.raw`^(?<protocol>mongodb(?:\+srv|)):\/\/(?:(?<username>[^:]*)(?::(?<password>[^@]*))?@)?(?<hosts>(?!:)[^\/?@]+)(?<rest>.*)`
+  String.raw`^(?<protocol>mongodb(?:\+srv|)):\/\/(?:(?<username>[^:]*)(?::(?<password>[^@]*))?@)?(?<hosts>(?!:)[^\/?@]+)?(?<rest>.*)`
 );
 
 class CaseInsensitiveMap<K extends string = string> extends Map<K, string> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ function connectionStringHasValidScheme(connectionString: string) {
 // Adapted from the Node.js driver code:
 // https://github.com/mongodb/node-mongodb-native/blob/350d14fde5b24480403313cfe5044f6e4b25f6c9/src/connection_string.ts#L146-L206
 const HOSTS_REGEX = new RegExp(
-  String.raw`^(?<protocol>mongodb(?:\+srv|)):\/\/(?:(?<username>[^:]*)(?::(?<password>[^@]*))?@)?(?<hosts>(?!:)[^\/?@]+)?(?<rest>.*)`
+  String.raw`^(?<protocol>mongodb(?:\+srv|)):\/\/(?:(?<username>[^:]*)(?::(?<password>[^@]*))?@)?(?<hosts>(?!:)[^\/?@]*)(?<rest>.*)`
 );
 
 class CaseInsensitiveMap<K extends string = string> extends Map<K, string> {

--- a/test/index.ts
+++ b/test/index.ts
@@ -114,7 +114,8 @@ describe('ConnectionString', () => {
       'mongodb+srv://a,b,c/',
       'mongodb+srv://a:12345/',
       'mongodbabc://localhost',
-      'totallynotamongodb://localhost'
+      'totallynotamongodb://localhost',
+      'mongodb+srv://Y:X@'
     ]) {
       it(`parsing ${uri} throws an MongoParseError`, () => {
         try {


### PR DESCRIPTION
Fix REGEX so we extract undefined host from uri and can check it later in code and throw a proper MongoParseError instead of TypeError that leads to returning DUMMY_HOSTNAME in the validation message on the Compass connect form.