### PR TITLE
fix: use looseValidation for cloning ConnectionString instances

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -221,7 +221,9 @@ export class ConnectionString extends URLWithoutHost {
   }
 
   clone(): ConnectionString {
-    return new ConnectionString(this.toString());
+    return new ConnectionString(this.toString(), {
+      looseValidation: true
+    });
   }
 
   redact(options?: ConnectionStringRedactionOptions): ConnectionString {


### PR DESCRIPTION
So that ones that were created with `looseValidation: true`
can also be cloned.