### PR TITLE
Move @types/whatwg-url to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/chai": "^4.2.5",
     "@types/mocha": "^8.0.3",
     "@types/node": "^14.11.1",
+    "@types/whatwg-url": "^8.2.1",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.2.0",
     "chai": "^4.2.0",
@@ -56,7 +57,6 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@types/whatwg-url": "^8.2.1",
     "whatwg-url": "^11.0.0"
   }
 }


### PR DESCRIPTION
In certain environments, trying to install `mongodb` without dev dependencies
will pull in `@types/whatwg-url` because this package lists it as a regular
dependency. This causes approx. 4.4 MB of extra files to be pulled in, including
`@types/node`.

https://packagephobia.com/result?p=mongodb-connection-string-url

This patch just moves it to the dev dependencies.
