### PR TITLE
fix(package.json): update whatwg-url version due to deprecation warni…

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@types/chai": "^4.2.5",
     "@types/mocha": "^8.0.3",
     "@types/node": "^14.11.1",
-    "@types/whatwg-url": "^11.0.2",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.2.0",
     "chai": "^4.2.0",
@@ -57,6 +56,7 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
+    "@types/whatwg-url": "^11.0.2",
     "whatwg-url": "^13.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@types/chai": "^4.2.5",
     "@types/mocha": "^8.0.3",
     "@types/node": "^14.11.1",
+    "@types/whatwg-url": "^11.0.2",
     "@typescript-eslint/eslint-plugin": "^4.2.0",
     "@typescript-eslint/parser": "^4.2.0",
     "chai": "^4.2.0",
@@ -56,7 +57,6 @@
     "typescript": "^4.7.4"
   },
   "dependencies": {
-    "@types/whatwg-url": "^8.2.1",
-    "whatwg-url": "^11.0.0"
+    "whatwg-url": "^13.0.0"
   }
 }


### PR DESCRIPTION
~In addition to~ resolving the problem addressed in issue #30, ~the `@types/whatwg-url` package has no place in `depedencies` and has therefore been updated in `devDependencies`.~