### PR TITLE
ci(NODE-6036): upgrade gha and add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+### Description
+
+#### What is changing?
+
+##### Is there new documentation needed for these changes?
+
+#### What is the motivation for this change?
+
+<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
+<!-- If this is a feature, it helps to describe the new use case enabled by this change -->
+
+<!--
+Contributors!
+First of all, thank you so much!!
+If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
+You can do that here: https://jira.mongodb.org/projects/NODE
+-->
+
+### Release Highlight
+
+<!-- RELEASE_HIGHLIGHT_START -->
+
+### Fill in title or leave empty for no highlight
+
+<!-- RELEASE_HIGHLIGHT_END -->
+
+### Double check the following
+
+- [ ] Ran `npm run check:lint` script
+- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
+- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
+  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
+- [ ] Changes are covered by tests
+- [ ] New TODOs have a related JIRA ticket

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@ You can do that here: https://jira.mongodb.org/projects/NODE
 
 ### Double check the following
 
-- [ ] Ran `npm run check:lint` script
+- [ ] Ran `npm run lint` script
 - [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
 - [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
   - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,9 +12,9 @@ jobs:
         node-version: [16.x, 18.x, 20.x]
     runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies


### PR DESCRIPTION
### Description

#### What is changing?

- Upgrade GHA
- Add dependabot config to ping us monthly

##### Is there new documentation needed for these changes?

No

#### What is the motivation for this change?

- Node.js 16 EOL

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [x] New TODOs have a related JIRA ticket
