### PR TITLE
chore(NODE-6514): update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,33 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    ignore:
+      # chai is esmodule only.
+      - dependency-name: "chai"
+        versions: [">=5.0.0"]
+      # sinon-chai 4.x+ supports chai 5.x+.
+      - dependency-name: "sinon-chai"
+        versions: [">=4.0.0"]
+      # chalk is esmodule only.
+      - dependency-name: "chalk"
+        versions: [">=5.0.0"]
+      # nyc is Node18+ only starting on nyc@16.x.
+      - dependency-name: "nyc"
+        versions: [">=16.0.0"]
+      # we ignore TS as a part of quarterly dependency updates.
+      - dependency-name: "typescript"
+    groups:
+      development-dependencies:
+        dependency-type: "development"
+        applies-to: version-updates
+        update-types:
+        - "minor"
+        - "patch"


### PR DESCRIPTION
### Description

Update the dependabot config to mirror our other configs.

#### What is changing?

Updates the dependabot config.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6514

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
