### PR TITLE
chore(NODE-6514): remove dependencies not in module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,12 +17,6 @@ updates:
       # chai is esmodule only.
       - dependency-name: "chai"
         versions: [">=5.0.0"]
-      # sinon-chai 4.x+ supports chai 5.x+.
-      - dependency-name: "sinon-chai"
-        versions: [">=4.0.0"]
-      # chalk is esmodule only.
-      - dependency-name: "chalk"
-        versions: [">=5.0.0"]
       # nyc is Node18+ only starting on nyc@16.x.
       - dependency-name: "nyc"
         versions: [">=16.0.0"]


### PR DESCRIPTION
### Description

Removes sinon-chai and chalk from dependabot config.

#### What is changing?

Deps configuration.

##### Is there new documentation needed for these changes?

None

#### What is the motivation for this change?

NODE-6514

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [x] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
