### PR TITLE
chore: update exports entry in package.json with type mappings

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,9 +16,16 @@
     "url": "https://github.com/mongodb-js/mongodb-connection-string-url/issues"
   },
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "exports": {
-    "require": "./lib/index.js",
-    "import": "./.esm-wrapper.mjs"
+    "require": {
+      "default": "./lib/index.js",
+      "types": "./lib/index.d.ts"
+    },
+    "import": {
+      "default": "./.esm-wrapper.mjs",
+      "types": "./lib/index.d.ts"
+    }
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
### Description
This PR proposes adding explicit type mappings in the exports entry of the package.json so that library consumers don't have to manually map types in their tsconfig, an example [here](https://github.com/mongodb-js/mongodb-mcp-server/pull/515/files#diff-3ae20d611c1c7263a9c1bce0449291ebfea1c5d578b3fcdbb596353ad885db25R21-R25).

#### What is changing?
We're adding an entry for types in the exports entry in package.json

##### Is there new documentation needed for these changes?
No

#### What is the motivation for this change?
We'd like to avoid doing explicit type mappings likes [this](https://github.com/mongodb-js/mongodb-mcp-server/pull/515/files#diff-3ae20d611c1c7263a9c1bce0449291ebfea1c5d578b3fcdbb596353ad885db25R21-R25).

<!-- If this is a bug, it helps to describe the current behavior and a clear outline of the expected behavior -->
<!-- If this is a feature, it helps to describe the new use case enabled by this change -->

<!--
Contributors!
First of all, thank you so much!!
If you haven't already, it would greatly help the team review this work in a timely manner if you create a JIRA ticket to track this PR.
You can do that here: https://jira.mongodb.org/projects/NODE
-->

### Release Highlight

<!-- RELEASE_HIGHLIGHT_START -->

### Fill in title or leave empty for no highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Ran `npm run lint` script
- [x] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
