### PR TITLE
Revert "chore: update exports entry in package.json with type mappings"

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,16 +16,9 @@
     "url": "https://github.com/mongodb-js/mongodb-connection-string-url/issues"
   },
   "main": "lib/index.js",
-  "types": "lib/index.d.ts",
   "exports": {
-    "require": {
-      "default": "./lib/index.js",
-      "types": "./lib/index.d.ts"
-    },
-    "import": {
-      "default": "./.esm-wrapper.mjs",
-      "types": "./lib/index.d.ts"
-    }
+    "require": "./lib/index.js",
+    "import": "./.esm-wrapper.mjs"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
Reverts mongodb-js/mongodb-connection-string-url#89

Reverting the merge because it was incorrectly categorised as `chore`.