### PR TITLE
chore: fix release action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,5 +10,6 @@ runs:
         registry-url: 'https://registry.npmjs.org'
     - run: npm install -g npm@latest
       shell: bash
-    - run: npm clean-install
+    # TODO(NODE-7058): use npm CI here once we have a package-lock.json again
+    - run: npm install
       shell: bash


### PR DESCRIPTION
### Description

#### Summary of Changes

This PR fixes the release action.  

Some past context:  This package depends on the npm package whatwg-url.  Version 13.x of of whatwg-url supports Node 16, but prints deprecation warnings when used.  Version 14.x does not support Node16 but does not used deprecated code.  We support both, and let npm choose which to install based on the user's Node version.  But this means that we can't have a package-lock file if we want our CI to install the correct version of whatwg-url in our CI, so we've removed the package-lock from this repo.  Once we are Node20+, we can add the package-lock.json back and update whatwg-url to 15.x, resolving this issue permanently.  This PR is a workaround so we can release one last version of mongodb-connection-string-url for devtools before the next major version.

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motiviation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Release notes highlight

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
