### PR TITLE
chore: Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,6 +5,8 @@ name: CI
 jobs:
   test:
     name: Test
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/mongodb-js/mongodb-connection-string-url/security/code-scanning/4](https://github.com/mongodb-js/mongodb-connection-string-url/security/code-scanning/4)

In general, the fix is to explicitly define a `permissions` block that grants only the minimal scopes required. This can be done either at the workflow root (applies to all jobs without their own `permissions`) or at the individual job level. For a simple CI test job that only checks out code and runs tests, `contents: read` is usually sufficient.

The single best way to fix this specific workflow without changing its functional behavior is to add a `permissions` block to the `test` job, directly under its `name: Test` line. This localizes the change and clearly documents the intended permissions for this job. The block should set `contents: read`, which allows checkout and read access to the repository but prevents unintended write operations via `GITHUB_TOKEN`. No new imports, methods, or other definitions are needed, as this is purely a YAML configuration change within `.github/workflows/nodejs.yml`.

Concretely, in `.github/workflows/nodejs.yml`, add:

```yaml
    permissions:
      contents: read
```

indented to align with `name:` and appearing between `name: Test` (line 7) and `strategy:` (line 8). No other lines need to be modified.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
