### PR TITLE
refactor(NODE-7445): replace whatwg-url with native URL/URLSearchParams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,6 @@
       "name": "mongodb-connection-string-url",
       "version": "7.0.1",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@types/whatwg-url": "^13.0.0",
-        "whatwg-url": "^14.1.0"
-      },
       "devDependencies": {
         "@types/chai": "^5.0.1",
         "@types/mocha": "^10.0.10",
@@ -66,6 +62,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -897,23 +894,9 @@
       "integrity": "sha512-3E97nlWEVp2V6J7aMkR8eOnw/w0pArPwf/5/W0865f+xzBoGL/ZuHkTAKAGN7cOWNwd+sG+hZOqj+fjzeHS75g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/webidl-conversions": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
-      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/whatwg-url": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
-      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/webidl-conversions": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -952,6 +935,7 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -1157,6 +1141,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1517,6 +1502,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -2252,6 +2238,7 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2313,6 +2300,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5149,6 +5137,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6054,18 +6043,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/ts-api-utils": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -6296,6 +6273,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6397,28 +6375,6 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^5.1.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -61,10 +61,7 @@
     "ts-node": "^10.9.1",
     "typescript": "^5.9.2"
   },
-  "dependencies": {
-    "@types/whatwg-url": "^13.0.0",
-    "whatwg-url": "^14.1.0"
-  },
+  "dependencies": {},
   "engines": {
     "node": ">=20.19.0"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { URL, URLSearchParams } from 'whatwg-url';
 import {
   redactValidConnectionString,
   redactConnectionString,
@@ -95,23 +94,20 @@ function caseInsenstiveURLSearchParams<K extends string = string>(Ctor: typeof U
   };
 }
 
-// Abstract middle class to appease TypeScript, see https://github.com/microsoft/TypeScript/pull/37894
-abstract class URLWithoutHost extends URL {
-  abstract get host(): never;
-  abstract set host(value: never);
-  abstract get hostname(): never;
-  abstract set hostname(value: never);
-  abstract get port(): never;
-  abstract set port(value: never);
-  abstract get href(): string;
-  abstract set href(value: string);
-}
-
 class MongoParseError extends Error {
   get name(): string {
     return 'MongoParseError';
   }
 }
+
+// The native URL class declares host, hostname, port, and href as properties
+// in its TypeScript type definitions. ConnectionString needs to override these
+// with accessors, which TypeScript does not allow (TS2611). We work around this
+// by re-typing the URL constructor to omit the conflicting property declarations.
+const URLBase = URL as unknown as {
+  new (url: string | URL, base?: string | URL): Omit<URL, 'host' | 'hostname' | 'port' | 'href' | 'toString'>;
+  prototype: Omit<URL, 'host' | 'hostname' | 'port' | 'href' | 'toString'>;
+};
 
 export interface ConnectionStringParsingOptions {
   looseValidation?: boolean;
@@ -121,7 +117,7 @@ export interface ConnectionStringParsingOptions {
  * Represents a mongodb:// or mongodb+srv:// connection string.
  * See: https://github.com/mongodb/specifications/blob/master/source/connection-string/connection-string-spec.rst#reference-implementation
  */
-export class ConnectionString extends URLWithoutHost {
+export class ConnectionString extends URLBase {
   _hosts: string[];
 
   // eslint-disable-next-line complexity


### PR DESCRIPTION
## Summary

Removes `whatwg-url` and `@types/whatwg-url` as runtime dependencies. Since v7.0.0 requires Node >= 20.19.0, the native `URL` implementation (Ada-backed since Node 18) is already WHATWG-compliant, making the polyfill unnecessary.

There's no open issue for this — I expect this is something you're already aware of and just haven't gotten around to. Happy to adjust anything.

## What changed

- Removed `whatwg-url` and `@types/whatwg-url` from dependencies
- Removed the `import { URL, URLSearchParams } from 'whatwg-url'` import
- Replaced the `URLWithoutHost` abstract class with a re-typed `URLBase` constant using `Omit<>` to handle the TS2611 property-vs-accessor conflict with native URL's type declarations

All 61 existing tests pass without modification. Also verified with the `mongodb` driver in a test project — parsing, redaction, cloning, and case-insensitive params all work as expected.