### PR TITLE
chore(NODE-7568): migrate release workflow to npm Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,15 +6,12 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 name: release
 
 jobs:
   release-please:
-    permissions:
-      id-token: write
-      contents: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - id: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,15 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 
 name: release
 
 jobs:
   release-please:
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - id: release
@@ -25,5 +28,3 @@ jobs:
         uses: ./.github/actions/setup
       - if: ${{ steps.release.outputs.release_created }}
         run: npm publish --provenance --tag latest
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,22 +6,27 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 
 name: release
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
     steps:
       - id: release
         uses: googleapis/release-please-action@v4
 
-      # If release-please created a release, publish to npm
-      - if: ${{ steps.release.outputs.release_created }}
-        uses: actions/checkout@v5
-      - if: ${{ steps.release.outputs.release_created }}
-        name: actions/setup
+  publish:
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.release_created }}
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: actions/setup
         uses: ./.github/actions/setup
-      - if: ${{ steps.release.outputs.release_created }}
-        run: npm publish --provenance --tag latest
+      - run: npm publish --provenance --tag latest


### PR DESCRIPTION
### Description

#### Summary of Changes

Migrate `mongodb-connection-string-url` off `NPM_TOKEN` and onto npm Trusted Publishing (OIDC) per [NODE-7568](https://jira.mongodb.org/browse/NODE-7568).

Since this repo has a single release workflow, `release.yml` is registered directly as the trusted publisher on npmjs.com — no separate `npm-publish.yml` indirection needed.

The only change needed is removing `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the publish step — `id-token: write` was already present at the workflow level, so `npm publish --provenance` can obtain the OIDC token automatically.

##### Notes for Reviewers

**Before merging:** An npm Trusted Publishing entry must be configured on npmjs.com for the `mongodb-connection-string-url` package, pointing at `.github/workflows/release.yml` in this repo. Once verified, `NPM_TOKEN` can be removed from the repo secrets and the package switched to "Require two-factor authentication and disallow tokens."

### Double check the following

- [ ] Lint is passing
- [ ] Self-review completed
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket