### PR TITLE
fix(NODE-7597): handle unescaped @ in the password

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -181,10 +181,6 @@ export class ConnectionString extends URLWithoutHost {
 
     try {
       super(`${protocol.toLowerCase()}://${authString}${DUMMY_HOSTNAME}${rest}`);
-
-      if ((username ?? '') !== this.username || (password ?? '') !== this.password) {
-        throw new MongoParseError(`Invalid connection string ${uri}. Username and password must be percent-encoded.`);
-      }
     } catch (err: any) {
       if (looseValidation) {
         // Call the constructor again, this time with loose validation off,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,7 @@ function connectionStringHasValidScheme(connectionString: string) {
 // Adapted from the Node.js driver code:
 // https://github.com/mongodb/node-mongodb-native/blob/350d14fde5b24480403313cfe5044f6e4b25f6c9/src/connection_string.ts#L146-L206
 const HOSTS_REGEX =
-  /^(?<protocol>[^/]+):\/\/(?:(?<username>[^:@]*)(?::(?<password>[^@]*))?@)?(?<hosts>(?!:)[^/?@]*)(?<rest>.*)/;
-
+  /^(?<protocol>[^/]+):\/\/(?:(?<username>[^:@]*)(?::(?<password>[^/?]*))?@)?(?<hosts>(?!:)[^/?@]*)(?<rest>.*)/;
 class CaseInsensitiveMap<K extends string = string> extends Map<K, string> {
   delete(name: K): boolean {
     return super.delete(this._normalizeKey(name));

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,11 @@ export class ConnectionString extends URLWithoutHost {
       if (password?.match(illegalCharacters)) {
         throw new MongoParseError('Password contains unescaped characters');
       }
+
+      // unexpected @ encountered
+      if (rest?.match(/^([^?]*)@/)) {
+        throw new MongoParseError(`Invalid connection string ${uri}`);
+      }
     }
 
     let authString = '';
@@ -260,11 +265,6 @@ export class ConnectionString extends URLWithoutHost {
   }
 
   clone(): ConnectionString {
-    console.log({
-      toString: this.toString(),
-      username: this.username,
-      password: this.password,
-    })
     return new ConnectionString(this.toString(), {
       looseValidation: true
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,8 @@ function connectionStringHasValidScheme(connectionString: string) {
 // Adapted from the Node.js driver code:
 // https://github.com/mongodb/node-mongodb-native/blob/350d14fde5b24480403313cfe5044f6e4b25f6c9/src/connection_string.ts#L146-L206
 const HOSTS_REGEX =
-  /^(?<protocol>[^/]+):\/\/(?:(?<username>[^:@]*)(?::(?<password>[^/?]*))?@)?(?<hosts>(?!:)[^/?@]*)(?<rest>.*)/;
+  /^(?<protocol>[^/]+):\/\/(?:(?<username>[^:@]*)(?::(?<password>[^@]*))?@)?(?<hosts>(?!:)[^/?@]*)(?<rest>.*)/;
+
 class CaseInsensitiveMap<K extends string = string> extends Map<K, string> {
   delete(name: K): boolean {
     return super.delete(this._normalizeKey(name));
@@ -175,6 +176,10 @@ export class ConnectionString extends URLWithoutHost {
 
     try {
       super(`${protocol.toLowerCase()}://${authString}${DUMMY_HOSTNAME}${rest}`);
+
+      if ((username ?? '') !== this.username || (password ?? '') !== this.password) {
+        throw new MongoParseError(`Invalid connection string ${uri}. Username and password must be percent-encoded.`);
+      }
     } catch (err: any) {
       if (looseValidation) {
         // Call the constructor again, this time with loose validation off,
@@ -255,6 +260,11 @@ export class ConnectionString extends URLWithoutHost {
   }
 
   clone(): ConnectionString {
+    console.log({
+      toString: this.toString(),
+      username: this.username,
+      password: this.password,
+    })
     return new ConnectionString(this.toString(), {
       looseValidation: true
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,7 +169,7 @@ export class ConnectionString extends URLWithoutHost {
       }
 
       // unexpected @ encountered
-      if (rest?.match(/^[^?]*@/)) {
+      if (rest?.match(/^[^/?]*@/)) {
         throw new MongoParseError(`Invalid connection string "${uri}"`);
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,7 +169,7 @@ export class ConnectionString extends URLWithoutHost {
       }
 
       // unexpected @ encountered
-      if (rest?.match(/^[^/?]*@/)) {
+      if (rest?.match(/^[^?]*@/)) {
         throw new MongoParseError(`Invalid connection string "${uri}"`);
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,8 +169,8 @@ export class ConnectionString extends URLWithoutHost {
       }
 
       // unexpected @ encountered
-      if (rest?.match(/^([^?]*)@/)) {
-        throw new MongoParseError(`Invalid connection string ${uri}`);
+      if (rest?.match(/^[^?]*@/)) {
+        throw new MongoParseError(`Invalid connection string "${uri}"`);
       }
     }
 

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -52,17 +52,13 @@ export function redactConnectionString(
     // squash errors
   }
   if (parsed) {
-    try {
-      // If we can parse the connection string, use the more precise
-      // redaction logic.
-      options = { ...options, replacementString: '___credentials___' };
-      return parsed
-        .redact(options)
-        .toString()
-        .replace(/___credentials___/g, replacementString);
-    } catch {
-      // Also squash errors
-    }
+    // If we can parse the connection string, use the more precise
+    // redaction logic.
+    options = { ...options, replacementString: '___credentials___' };
+    return parsed
+      .redact(options)
+      .toString()
+      .replace(/___credentials___/g, replacementString);
   }
 
   // Note: The regexes here used to use lookbehind assertions, but we dropped that since

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -52,13 +52,17 @@ export function redactConnectionString(
     // squash errors
   }
   if (parsed) {
-    // If we can parse the connection string, use the more precise
-    // redaction logic.
-    options = { ...options, replacementString: '___credentials___' };
-    return parsed
-      .redact(options)
-      .toString()
-      .replace(/___credentials___/g, replacementString);
+    try {
+      // If we can parse the connection string, use the more precise
+      // redaction logic.
+      options = { ...options, replacementString: '___credentials___' };
+      return parsed
+        .redact(options)
+        .toString()
+        .replace(/___credentials___/g, replacementString);
+    } catch {
+      // Also squash errors
+    }
   }
 
   // Note: The regexes here used to use lookbehind assertions, but we dropped that since

--- a/test/index.ts
+++ b/test/index.ts
@@ -132,7 +132,8 @@ describe('ConnectionString', () => {
       'mongodb+srv://a:12345/',
       'mongodbabc://localhost',
       'totallynotamongodb://localhost',
-      'mongodb+srv://Y:X@'
+      'mongodb+srv://Y:X@',
+      'mongodb+srv://user:p@ss@localhost/',
     ]) {
       it(`parsing ${uri} throws an MongoParseError`, () => {
         try {

--- a/test/index.ts
+++ b/test/index.ts
@@ -135,7 +135,13 @@ describe('ConnectionString', () => {
       'mongodb+srv://Y:X@',
       'mongodb+srv://user:p@ss@localhost/',
       'mongodb+srv://us@r:pass@localhost/',
-      'mongodb+srv://user:p@ssw#rd@localhost/'
+      'mongodb+srv://user:p@ssw#rd@localhost/',
+      'mongodb://user:p@ss@localhost/',
+      'mongodb://us@r:pass@localhost/',
+      'mongodb://user:p@ssw#rd@localhost/',
+      'mongodb://user:pass/word@localhost/',
+      'mongodb://user:pass?word@localhost/',
+      'mongodb+srv://us@r:pass@localhost/'
     ]) {
       it(`parsing ${uri} throws an MongoParseError`, () => {
         try {

--- a/test/index.ts
+++ b/test/index.ts
@@ -135,7 +135,7 @@ describe('ConnectionString', () => {
       'mongodb+srv://Y:X@',
       'mongodb+srv://user:p@ss@localhost/',
       'mongodb+srv://us@r:pass@localhost/',
-      'mongodb+srv://user:p@ssw#rd@localhost/',
+      'mongodb+srv://user:p@ssw#rd@localhost/'
     ]) {
       it(`parsing ${uri} throws an MongoParseError`, () => {
         try {

--- a/test/index.ts
+++ b/test/index.ts
@@ -133,7 +133,7 @@ describe('ConnectionString', () => {
       'mongodbabc://localhost',
       'totallynotamongodb://localhost',
       'mongodb+srv://Y:X@',
-      'mongodb+srv://user:p@ss@localhost/',
+      'mongodb+srv://user:p@ss@localhost/'
     ]) {
       it(`parsing ${uri} throws an MongoParseError`, () => {
         try {

--- a/test/index.ts
+++ b/test/index.ts
@@ -143,7 +143,6 @@ describe('ConnectionString', () => {
       'mongodb://us/er@localhost', // invalid because of user
       'mongodb://localhost/d@tabase', // invalid because of db
       'mongodb://user:pass?word@localhost/',
-      'mongodb+srv://us@r:pass@localhost/',
 
       // ambiguous strings
       // 'mongodb://localhost?key=a:b@c@d/', - valid

--- a/test/index.ts
+++ b/test/index.ts
@@ -133,7 +133,9 @@ describe('ConnectionString', () => {
       'mongodbabc://localhost',
       'totallynotamongodb://localhost',
       'mongodb+srv://Y:X@',
-      'mongodb+srv://user:p@ss@localhost/'
+      'mongodb+srv://user:p@ss@localhost/',
+      'mongodb+srv://us@r:pass@localhost/',
+      'mongodb+srv://user:p@ssw#rd@localhost/',
     ]) {
       it(`parsing ${uri} throws an MongoParseError`, () => {
         try {

--- a/test/index.ts
+++ b/test/index.ts
@@ -140,8 +140,14 @@ describe('ConnectionString', () => {
       'mongodb://us@r:pass@localhost/',
       'mongodb://user:p@ssw#rd@localhost/',
       'mongodb://user:pass/word@localhost/',
+      'mongodb://us/er@localhost', // invalid because of user
+      'mongodb://localhost/d@tabase', // invalid because of db
       'mongodb://user:pass?word@localhost/',
-      'mongodb+srv://us@r:pass@localhost/'
+      'mongodb+srv://us@r:pass@localhost/',
+
+      // ambiguous strings
+      // 'mongodb://localhost?key=a:b@c@d/', - valid
+      // 'mongodb://u?er:p@ss@localhost/' - invalid
     ]) {
       it(`parsing ${uri} throws an MongoParseError`, () => {
         try {

--- a/test/index.ts
+++ b/test/index.ts
@@ -88,20 +88,6 @@ describe('ConnectionString', () => {
           isSRV: false,
           hosts: ['database-haha.mongo.blah.blah.com:8888']
         }
-      },
-      {
-        uri: 'mongodb://user:pass@localhost/d@tabase',
-        match: {
-          href: 'mongodb://user:pass@localhost/d@tabase',
-          protocol: 'mongodb:',
-          username: 'user',
-          password: 'pass',
-          pathname: '/d@tabase',
-          search: '',
-          hash: '',
-          isSRV: false,
-          hosts: ['localhost']
-        }
       }
     ]) {
       it(`parses ${uri} correctly`, () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -135,6 +135,7 @@ describe('ConnectionString', () => {
       'mongodb+srv://Y:X@',
       'mongodb+srv://user:p@ss@localhost/',
       'mongodb+srv://us@r:pass@localhost/',
+      'mongodb+srv://us@r:p@ss@localhost/',
       'mongodb+srv://user:p@ssw#rd@localhost/',
       'mongodb://user:p@ss@localhost/',
       'mongodb://us@r:pass@localhost/',

--- a/test/index.ts
+++ b/test/index.ts
@@ -88,7 +88,21 @@ describe('ConnectionString', () => {
           isSRV: false,
           hosts: ['database-haha.mongo.blah.blah.com:8888']
         }
-      }
+      },
+      {
+        uri: 'mongodb://user:pass@localhost/d@tabase',
+        match: {
+          href: 'mongodb://user:pass@localhost/d@tabase',
+          protocol: 'mongodb:',
+          username: 'user',
+          password: 'pass',
+          pathname: '/d@tabase',
+          search: '',
+          hash: '',
+          isSRV: false,
+          hosts: ['localhost']
+        }
+      },
     ]) {
       it(`parses ${uri} correctly`, () => {
         const cs = new ConnectionString(uri);
@@ -141,8 +155,7 @@ describe('ConnectionString', () => {
       'mongodb://us@r:pass@localhost/',
       'mongodb://user:p@ssw#rd@localhost/',
       'mongodb://user:pass/word@localhost/',
-      'mongodb://us/er@localhost', // invalid because of user
-      'mongodb://localhost/d@tabase', // invalid because of db
+      'mongodb://us/er@localhost',
       'mongodb://user:pass?word@localhost/'
     ]) {
       it(`parsing ${uri} throws an MongoParseError`, () => {

--- a/test/index.ts
+++ b/test/index.ts
@@ -142,11 +142,7 @@ describe('ConnectionString', () => {
       'mongodb://user:pass/word@localhost/',
       'mongodb://us/er@localhost', // invalid because of user
       'mongodb://localhost/d@tabase', // invalid because of db
-      'mongodb://user:pass?word@localhost/',
-
-      // ambiguous strings
-      // 'mongodb://localhost?key=a:b@c@d/', - valid
-      // 'mongodb://u?er:p@ss@localhost/' - invalid
+      'mongodb://user:pass?word@localhost/'
     ]) {
       it(`parsing ${uri} throws an MongoParseError`, () => {
         try {

--- a/test/index.ts
+++ b/test/index.ts
@@ -102,7 +102,7 @@ describe('ConnectionString', () => {
           isSRV: false,
           hosts: ['localhost']
         }
-      },
+      }
     ]) {
       it(`parses ${uri} correctly`, () => {
         const cs = new ConnectionString(uri);

--- a/test/index.ts
+++ b/test/index.ts
@@ -88,6 +88,20 @@ describe('ConnectionString', () => {
           isSRV: false,
           hosts: ['database-haha.mongo.blah.blah.com:8888']
         }
+      },
+      {
+        uri: 'mongodb://user:pass@localhost/d@tabase',
+        match: {
+          href: 'mongodb://user:pass@localhost/d@tabase',
+          protocol: 'mongodb:',
+          username: 'user',
+          password: 'pass',
+          pathname: '/d@tabase',
+          search: '',
+          hash: '',
+          isSRV: false,
+          hosts: ['localhost']
+        }
       }
     ]) {
       it(`parses ${uri} correctly`, () => {


### PR DESCRIPTION
### Description

#### Summary of Changes

Previously, a string such as `mongodb+srv://user:p@ss@localhost/` would mistakenly pass as valid in the ConnectionString in the constructor. 
Furthermore, `redactConnectionString` didn't use the fallback if `.redact` failed after the constructor passed (the expectation being that this would not happen but apparently stuff happens 😂).

#### What is the motivation for this change?

Upstream mistakenly expecting that `redactConnectionString` would not throw lead to
https://jira.mongodb.org/browse/COMPASS-10688


### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Fixed parsing issue

Unescaped `@` in credentials now throws instead of silently misparsing.

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
