### PR TITLE
fix(NODE-7665): uri disclosure on error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,14 +135,14 @@ export class ConnectionString extends URLWithoutHost {
 
     const match = uri.match(HOSTS_REGEX);
     if (!match) {
-      throw new MongoParseError(`Invalid connection string "${uri}"`);
+      throw new MongoParseError(`Invalid connection string`);
     }
 
     const { protocol, username, password, hosts, rest } = match.groups ?? {};
 
     if (!looseValidation) {
       if (!protocol || !hosts) {
-        throw new MongoParseError(`Protocol and host list are required in "${uri}"`);
+        throw new MongoParseError(`Protocol and host list are required in the uri`);
       }
 
       try {
@@ -170,7 +170,7 @@ export class ConnectionString extends URLWithoutHost {
 
       // unexpected @ encountered
       if (rest?.match(/^[^/?]*@/)) {
-        throw new MongoParseError(`Invalid connection string "${uri}"`);
+        throw new MongoParseError(`Invalid connection string`);
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,14 +135,14 @@ export class ConnectionString extends URLWithoutHost {
 
     const match = uri.match(HOSTS_REGEX);
     if (!match) {
-      throw new MongoParseError(`Invalid connection string`);
+      throw new MongoParseError('Invalid connection string');
     }
 
     const { protocol, username, password, hosts, rest } = match.groups ?? {};
 
     if (!looseValidation) {
       if (!protocol || !hosts) {
-        throw new MongoParseError(`Protocol and host list are required in the uri`);
+        throw new MongoParseError('Protocol and host list are required in the uri');
       }
 
       try {
@@ -170,7 +170,7 @@ export class ConnectionString extends URLWithoutHost {
 
       // unexpected @ encountered
       if (rest?.match(/^[^/?]*@/)) {
-        throw new MongoParseError(`Invalid connection string`);
+        throw new MongoParseError('Invalid connection string');
       }
     }
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -180,7 +180,6 @@ describe('ConnectionString', () => {
         expect.fail('missed exception');
       } catch (err) {
         expect((err as Error).name).to.equal('MongoParseError');
-        expect((err as Error).message).to.equal('Invalid connection string');
         expect((err as Error).message).not.to.include(secret);
       }
     });
@@ -193,7 +192,6 @@ describe('ConnectionString', () => {
         expect.fail('missed exception');
       } catch (err) {
         expect((err as Error).name).to.equal('MongoParseError');
-        expect((err as Error).message).to.equal('Protocol and host list are required in the uri');
         expect((err as Error).message).not.to.include(secret);
       }
     });
@@ -206,7 +204,6 @@ describe('ConnectionString', () => {
         expect.fail('missed exception');
       } catch (err) {
         expect((err as Error).name).to.equal('MongoParseError');
-        expect((err as Error).message).to.equal('Invalid connection string');
         expect((err as Error).message).not.to.include(secret);
       }
     });

--- a/test/index.ts
+++ b/test/index.ts
@@ -171,6 +171,47 @@ describe('ConnectionString', () => {
     }
   });
 
+  context('error messages do not disclose the connection string', () => {
+    it('does not include the uri when it does not match the expected format', () => {
+      const secret = 'sw0rdf1sh';
+      try {
+        // eslint-disable-next-line no-new
+        new ConnectionString(`notauri${secret}`, { looseValidation: true });
+        expect.fail('missed exception');
+      } catch (err) {
+        expect((err as Error).name).to.equal('MongoParseError');
+        expect((err as Error).message).to.equal('Invalid connection string');
+        expect((err as Error).message).not.to.include(secret);
+      }
+    });
+
+    it('does not include the uri when the protocol or host list is missing', () => {
+      const secret = 'sw0rdf1sh';
+      try {
+        // eslint-disable-next-line no-new
+        new ConnectionString(`mongodb:///${secret}`);
+        expect.fail('missed exception');
+      } catch (err) {
+        expect((err as Error).name).to.equal('MongoParseError');
+        expect((err as Error).message).to.equal('Protocol and host list are required in the uri');
+        expect((err as Error).message).not.to.include(secret);
+      }
+    });
+
+    it('does not include the uri or password when an unexpected @ is encountered', () => {
+      const secret = 'sw0rdf1sh';
+      try {
+        // eslint-disable-next-line no-new
+        new ConnectionString(`mongodb://user:${secret}@ss@localhost/`);
+        expect.fail('missed exception');
+      } catch (err) {
+        expect((err as Error).name).to.equal('MongoParseError');
+        expect((err as Error).message).to.equal('Invalid connection string');
+        expect((err as Error).message).not.to.include(secret);
+      }
+    });
+  });
+
   context('after modifications', () => {
     it('allows changing hosts', () => {
       const cs = new ConnectionString('mongodb://localhost');


### PR DESCRIPTION
### Description

#### Summary of Changes

Prevents disclosure of invalid uri's in logs, reducing sensitive information disclosure.

##### Notes for Reviewers

<!-- 
If there is any additional context on the changes in the PR that reviewers might find helpful, feel free to make notes in this section.

Otherwise, feel free to remove this section.
-->

#### What is the motivation for this change?

<!--
Remove this section if there is an associated Jira ticket explaining the motivation for this change. If there is not, please fill this section out with 
information explaining why this change is valuable.
-->

### Release Highlight

<!-- 
Contributors: please leave the release notes section for the Node driver team to fill in. The following instructions are for maintainers.

For user facing changes: please provide release notes. Feel free to browse previous releases for example release highlights.

If there are no user-facing changes in this PR, please delete the release highlight section from the PR description.
-->

<!-- RELEASE_HIGHLIGHT_START -->

### Error messages no longer reveal invalid connection strings

Invalid connection strings are no longer revealed in error messages, reducing sensitive information disclosure. Historically we've had URI's embedded in error messages from validation failures. 

<!-- RELEASE_HIGHLIGHT_END -->

### Double check the following

- [x] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [x] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
