### PR TITLE
docs(NODE-7686): add AGENTS.md file

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Instructions for AI coding agents working in this repository. This file is the s
 
 ## Project Overview
 
-A [specification](https://github.com/mongodb/specifications/blob/master/source/connection-string/connection-string-spec.md)-compliant parser library for MongoDB connection string URLs, built on the WhatWG URL API.
+A parser library for MongoDB connection string URLs.
 
 ## Commands
 
@@ -28,6 +28,10 @@ npm run compile-ts   # type-check/compile only (fastest feedback)
 - **Errors** — throw `MongoParseError` for invalid connection strings; messages in sentence case, no trailing period. Never include the raw URI (credentials) in error messages.
 - **Formatting** — Prettier via eslint: single quotes, 2-space indent. Run `npm run lint` before committing.
 - **Tests** — every behavior change needs a mocha test; type-signature changes need a tsd test in `test/types/`.
+
+## Other Important Information
+
+- Changes must be compliant with the [connection string spec](https://github.com/mongodb/specifications/blob/master/source/connection-string/connection-string-spec.md).
 
 ## Commit Messages
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md
+
+Instructions for AI coding agents working in this repository. This file is the source of truth; tool-specific files (e.g. CLAUDE.md) should only import it.
+
+## Project Overview
+
+A [specification](https://github.com/mongodb/specifications/blob/master/source/connection-string/connection-string-spec.md)-compliant parser library for MongoDB connection string URLs, built on the WhatWG URL API.
+
+## Commands
+
+```bash
+npm run build        # compile TypeScript to lib/ and generate ESM wrapper
+npm test             # build, run tsd type tests, then mocha with coverage
+npm run lint         # runs an eslint pass
+npm run compile-ts   # type-check/compile only (fastest feedback)
+```
+
+## Structure
+
+- [src/index.ts](src/index.ts) — parsing logic
+- [src/redact.ts](src/redact.ts) — credential redactors for connection strings
+- `test/*.ts` — mocha + chai tests;
+- `test/types/*` — tsd type-level tests
+
+## Code Conventions
+
+- **Public API stability** — everything exported from `src/index.ts` is public API. Renaming, removing, or narrowing exported types/signatures is a breaking change; confirm with a maintainer first.
+- **Errors** — throw `MongoParseError` for invalid connection strings; messages in sentence case, no trailing period. Never include the raw URI (credentials) in error messages.
+- **Formatting** — Prettier via eslint: single quotes, 2-space indent. Run `npm run lint` before committing.
+- **Tests** — every behavior change needs a mocha test; type-signature changes need a tsd test in `test/types/`.
+
+## Commit Messages
+
+[Conventional Commits](https://www.conventionalcommits.org/) with a Jira ticket: `<type>(NODE-XXXX): <subject>` — types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`; breaking changes use `!` (e.g. `feat(NODE-XXXX)!: …`).
+
+## Related Repositories
+
+Direct dependents maintained by MongoDB — changes to public API or parsing behavior ripple into these:
+
+| Repo | Why it matters |
+| --- | --- |
+| [node-mongodb-native](https://github.com/mongodb/node-mongodb-native) | The Node.js driver; parses every user connection string. Parsing or API regressions break connections. |
+| [mongosh](https://github.com/mongodb-js/mongosh) | The MongoDB shell; option handling and redaction changes affect how it connects and displays URIs. |
+| [devtools-shared](https://github.com/mongodb-js/devtools-shared) | Shared Compass/devtools packages; changes propagate to every tool built on them. |
+| [compass](https://github.com/mongodb-js/compass/) | Compass GUI; builds and edits connection strings, surfacing behavior/redaction changes to end users. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,2 @@
+  @AGENTS.md
+  

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,1 @@
-  @AGENTS.md
-  
+@AGENTS.md

--- a/README.md
+++ b/README.md
@@ -19,7 +19,18 @@ console.log(cs.href); // 'mongodb://localhost/?readPreference=secondary'
 - The `.href` property cannot be set, only read
 - There is an additional `.isSRV` property, set to `true` for `mongodb+srv://`
 - There is an additional `.clone()` utility method on the prototype
+  
+## AI Agent Configuration
+This repository uses [agentskills.io](https://agentskills.io) conventions for AI coding agent
+instructions. `AGENTS.md` is the canonical source of truth — tool-specific files like `CLAUDE.md`
+are generated references.
 
+### Adding a nested AGENTS.md
+
+1. Create an `AGENTS.md` in the target directory.
+2. Run `scripts/symlink-claude-md.sh` to generate the companion `CLAUDE.md`.
+3. Stage and commit both files.
+ 
 ## LICENSE
 
 Apache-2.0

--- a/scripts/symlink-claude-md.sh
+++ b/scripts/symlink-claude-md.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# 1. Ensure every staged AGENTS.md has a companion CLAUDE.md containing
+#    "@AGENTS.md" (a Claude Code import reference).
+# 2. Ensure .claude/skills is a symlink to .agents/skills.
+
+set -euo pipefail
+
+claude_file_for_agents() {
+  local agents_file="$1"
+  local dir
+
+  dir=$(dirname "$agents_file")
+
+  if [ "$dir" = "." ]; then
+    printf 'CLAUDE.md\n'
+  else
+    printf '%s/CLAUDE.md\n' "$dir"
+  fi
+}
+
+remove_generated_file() {
+  local generated_file="$1"
+
+  if git ls-files --error-unmatch -- "$generated_file" > /dev/null 2>&1 || [ -e "$generated_file" ]; then
+    rm -f "$generated_file"
+    git add -u -- "$generated_file"
+    echo "auto-removed: $generated_file"
+  fi
+}
+
+sync_claude_skills_dir() {
+  local claude_skills_dir=".claude/skills"
+  local expected_target="../.agents/skills"
+  local current_target
+
+  if [ -L "$claude_skills_dir" ]; then
+    current_target=$(readlink "$claude_skills_dir")
+    if [ "$current_target" = "$expected_target" ]; then
+      return
+    fi
+
+    rm -f "$claude_skills_dir"
+  elif [ -e "$claude_skills_dir" ]; then
+    rm -rf "$claude_skills_dir"
+  fi
+
+  mkdir -p .claude
+  ln -s "$expected_target" "$claude_skills_dir"
+  git add "$claude_skills_dir"
+  echo "auto-synced: $claude_skills_dir -> $expected_target"
+}
+
+sync_claude_skills_dir
+
+staged_agents=()
+deleted_agents=()
+
+while IFS=$'\t ' read -r status first_path second_path; do
+  [ -n "$status" ] || continue
+
+  case "$status" in
+    R*)
+      if [[ "$first_path" =~ (^|/)AGENTS\.md$ ]]; then
+        deleted_agents+=("$first_path")
+      fi
+      if [[ "$second_path" =~ (^|/)AGENTS\.md$ ]]; then
+        staged_agents+=("$second_path")
+      fi
+      ;;
+    D)
+      if [[ "$first_path" =~ (^|/)AGENTS\.md$ ]]; then
+        deleted_agents+=("$first_path")
+      fi
+      ;;
+    *)
+      if [[ "$first_path" =~ (^|/)AGENTS\.md$ ]]; then
+        staged_agents+=("$first_path")
+      fi
+      ;;
+  esac
+done < <(git diff --cached --name-status --find-renames --diff-filter=ADMR)
+
+# --- CLAUDE.md sync ---
+if [ "${#staged_agents[@]}" -gt 0 ]; then
+  for agents_file in "${staged_agents[@]}"; do
+    claude_file=$(claude_file_for_agents "$agents_file")
+
+    # Skip if already a regular file with the correct content
+    if [ -f "$claude_file" ] && ! [ -L "$claude_file" ] && [ "$(cat "$claude_file")" = "@AGENTS.md" ]; then
+      continue
+    fi
+
+    # Remove symlink if present, then write the reference file
+    rm -f "$claude_file"
+    printf '@AGENTS.md\n' > "$claude_file"
+    git add "$claude_file"
+    echo "auto-created: $claude_file with @AGENTS.md reference"
+  done
+fi
+
+if [ "${#deleted_agents[@]}" -gt 0 ]; then
+  for agents_file in "${deleted_agents[@]}"; do
+    remove_generated_file "$(claude_file_for_agents "$agents_file")"
+  done
+fi
+


### PR DESCRIPTION
### Description

#### Summary of Changes

Adds an AGENTS.md file to the project root, giving key context to ai coding agents on session creation. Conforms with agentskills.io. Features a sync script to support nested AGENTS.md files. Scaffolds the directory for shared skills.

### Double check the following

- [ ] Lint is passing (`npm run check:lint`)
- [ ] Self-review completed using the [steps outlined here](https://github.com/mongodb/node-mongodb-native/blob/HEAD/CONTRIBUTING.md#reviewer-guidelines)
- [ ] PR title follows the [correct format](https://www.conventionalcommits.org/en/v1.0.0/): `type(NODE-xxxx)[!]: description`
  - Example: `feat(NODE-1234)!: rewriting everything in coffeescript`
- [ ] Changes are covered by tests
- [ ] New TODOs have a related JIRA ticket
